### PR TITLE
feat: 하단 탭 내비게이션 구현 및 북마크 화면 추가 (#22)

### DIFF
--- a/app/src/main/java/com/subin/cleanbookstore/MainActivity.kt
+++ b/app/src/main/java/com/subin/cleanbookstore/MainActivity.kt
@@ -4,12 +4,7 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Scaffold
-import androidx.compose.ui.Modifier
-import androidx.navigation.compose.rememberNavController
-import com.subin.cleanbookstore.presentation.navigation.MainNavHost
+import com.subin.cleanbookstore.presentation.MainScreen
 import com.subin.cleanbookstore.ui.theme.CleanBookStoreTheme
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -20,15 +15,8 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         setContent {
             CleanBookStoreTheme {
-                val navController = rememberNavController()
-                Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
-                    MainNavHost(
-                        navController = navController,
-                        modifier = Modifier.padding(innerPadding)
-                    )
-                }
+                MainScreen()
             }
-
         }
     }
 }

--- a/app/src/main/java/com/subin/cleanbookstore/presentation/MainScreen.kt
+++ b/app/src/main/java/com/subin/cleanbookstore/presentation/MainScreen.kt
@@ -1,0 +1,65 @@
+package com.subin.cleanbookstore.presentation
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Icon
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.navigation.NavDestination.Companion.hasRoute
+import androidx.navigation.NavGraph.Companion.findStartDestination
+import androidx.navigation.compose.currentBackStackEntryAsState
+import androidx.navigation.compose.rememberNavController
+import com.subin.cleanbookstore.presentation.navigation.MainNavHost
+import com.subin.cleanbookstore.presentation.navigation.NavRoute
+
+@Composable
+fun MainScreen() {
+    val navController = rememberNavController()
+    val navBackStackEntry by navController.currentBackStackEntryAsState()
+    val currentDestination = navBackStackEntry?.destination
+
+    val navigationItems = listOf(
+        NavRoute.Search,
+        NavRoute.Bookmark
+    )
+
+    Scaffold(
+        bottomBar = {
+            NavigationBar {
+                navigationItems.forEach { route ->
+                    val isSelected = currentDestination?.hasRoute(route::class) ?: false
+
+                    NavigationBarItem(
+                        icon = {
+                            val icon = if (route is NavRoute.Search) route.icon else (route as NavRoute.Bookmark).icon
+                            Icon(icon, contentDescription = null)
+                        },
+                        label = {
+                            val title = if (route is NavRoute.Search) route.title else (route as NavRoute.Bookmark).title
+                            Text(title)
+                        },
+                        selected = isSelected,
+                        onClick = {
+                            navController.navigate(route) {
+                                popUpTo(navController.graph.findStartDestination().id) {
+                                    saveState = true
+                                }
+                                launchSingleTop = true
+                                restoreState = true
+                            }
+                        }
+                    )
+                }
+            }
+        }
+    ) { innerPadding ->
+        MainNavHost(
+            navController = navController,
+            modifier = Modifier.padding(innerPadding)
+        )
+    }
+}

--- a/app/src/main/java/com/subin/cleanbookstore/presentation/bookmark/BookmarkScreen.kt
+++ b/app/src/main/java/com/subin/cleanbookstore/presentation/bookmark/BookmarkScreen.kt
@@ -1,0 +1,176 @@
+package com.subin.cleanbookstore.presentation.bookmark
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.subin.cleanbookstore.domain.model.Book
+import com.subin.cleanbookstore.presentation.components.BookItem
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun BookmarkScreen(
+    viewModel: BookmarkViewModel = hiltViewModel(),
+    onBookClick: (String) -> Unit
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    Scaffold(
+        topBar = {
+            CenterAlignedTopAppBar(
+                title = { Text("내 즐겨찾기") }
+            )
+        }
+    ) { paddingValues ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+        ) {
+            when (val state = uiState) {
+                is BookmarkUiState.Loading -> {
+                    CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
+                }
+                is BookmarkUiState.Success -> {
+                    if (state.bookmarks.isEmpty()) {
+                        EmptyBookmarkContent(modifier = Modifier.align(Alignment.Center))
+                    } else {
+                        LazyColumn(
+                            modifier = Modifier.fillMaxSize(),
+                            contentPadding = PaddingValues(bottom = 16.dp)
+                        ) {
+                            items(
+                                items = state.bookmarks,
+                                key = { it.id }
+                            ) { book ->
+                                BookItem(
+                                    book = book,
+                                    isLiked = true,
+                                    onClick = { onBookClick(book.id) },
+                                    onLikeClick = { viewModel.onBookmarkClick(book) }
+                                )
+                            }
+                        }
+                    }
+                }
+                is BookmarkUiState.Error -> {
+                    Text(
+                        text = state.message,
+                        color = MaterialTheme.colorScheme.error,
+                        modifier = Modifier.align(Alignment.Center)
+                    )
+                }
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun BookmarkScreenContent(
+    uiState: BookmarkUiState,
+    onBookClick: (String) -> Unit,
+    onLikeClick: (Book) -> Unit
+) {
+    Scaffold(
+        topBar = { CenterAlignedTopAppBar(title = { Text("내 즐겨찾기") }) }
+    ) { padding ->
+        Box(modifier = Modifier.fillMaxSize().padding(padding)) {
+            when (uiState) {
+                is BookmarkUiState.Loading -> CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
+                is BookmarkUiState.Success -> {
+                    if (uiState.bookmarks.isEmpty()) {
+                        EmptyBookmarkContent(modifier = Modifier.align(Alignment.Center))
+                    } else {
+                        LazyColumn {
+                            items(uiState.bookmarks) { book ->
+                                BookItem(book = book, isLiked = true, onClick = { onBookClick(book.id) }, onLikeClick = { onLikeClick(book) })
+                            }
+                        }
+                    }
+                }
+                is BookmarkUiState.Error -> Text(uiState.message, modifier = Modifier.align(Alignment.Center))
+            }
+        }
+    }
+}
+
+@Composable
+private fun EmptyBookmarkContent(modifier: Modifier = Modifier) {
+    Column(
+        modifier = modifier,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(
+            text = "아직 저장된 도서가 없습니다.",
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Text(
+            text = "마음에 드는 책을 찾아 북마크해 보세요!",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.outline
+        )
+    }
+}
+
+@Preview(showBackground = true, name = "북마크 리스트 있음")
+@Composable
+fun BookmarkScreenSuccessPreview() {
+    val mockBookmarks = listOf(
+        Book(
+            id = "1",
+            title = "클린 아키텍처",
+            subtitle = "소프트웨어 구조와 설계의 원칙",
+            authors = listOf("로버트 C. 마틴"),
+            publisher = "인사이트",
+            description = "",
+            imageUrl = "",
+            buyLink = "",
+            isFavorite = true
+        ),
+        Book(
+            id = "2",
+            title = "Kotlin in Action",
+            subtitle = "코틀린 핵심 원리",
+            authors = listOf("드미트리 제메로프"),
+            publisher = "에이콘",
+            description = "",
+            imageUrl = "",
+            buyLink = "",
+            isFavorite = true
+        )
+    )
+
+    MaterialTheme {
+        Surface {
+            BookmarkScreenContent(
+                uiState = BookmarkUiState.Success(mockBookmarks),
+                onBookClick = {},
+                onLikeClick = {}
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true, name = "북마크 비어있음")
+@Composable
+fun BookmarkScreenEmptyPreview() {
+    MaterialTheme {
+        Surface {
+            BookmarkScreenContent(
+                uiState = BookmarkUiState.Success(emptyList()),
+                onBookClick = {},
+                onLikeClick = {}
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/subin/cleanbookstore/presentation/bookmark/BookmarkUiState.kt
+++ b/app/src/main/java/com/subin/cleanbookstore/presentation/bookmark/BookmarkUiState.kt
@@ -1,0 +1,9 @@
+package com.subin.cleanbookstore.presentation.bookmark
+
+import com.subin.cleanbookstore.domain.model.Book
+
+sealed interface BookmarkUiState {
+    data object Loading : BookmarkUiState
+    data class Success(val bookmarks: List<Book>) : BookmarkUiState
+    data class Error(val message: String) : BookmarkUiState
+}

--- a/app/src/main/java/com/subin/cleanbookstore/presentation/bookmark/BookmarkViewModel.kt
+++ b/app/src/main/java/com/subin/cleanbookstore/presentation/bookmark/BookmarkViewModel.kt
@@ -1,0 +1,37 @@
+package com.subin.cleanbookstore.presentation.bookmark
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.subin.cleanbookstore.domain.model.Book
+import com.subin.cleanbookstore.domain.usecase.GetBookmarkListUseCase
+import com.subin.cleanbookstore.domain.usecase.ToggleBookmarkUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class BookmarkViewModel @Inject constructor(
+    private val getBookmarkListUseCase: GetBookmarkListUseCase,
+    private val toggleBookmarkUseCase: ToggleBookmarkUseCase
+) : ViewModel() {
+
+    val uiState: StateFlow<BookmarkUiState> = getBookmarkListUseCase()
+        .map { books ->
+            BookmarkUiState.Success(books) as BookmarkUiState
+        }
+        .catch { e ->
+            emit(BookmarkUiState.Error(e.message ?: "알 수 없는 오류"))
+        }
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5000),
+            initialValue = BookmarkUiState.Loading
+        )
+
+    fun onBookmarkClick(book: Book) {
+        viewModelScope.launch {
+            toggleBookmarkUseCase(book)
+        }
+    }
+}

--- a/app/src/main/java/com/subin/cleanbookstore/presentation/navigation/MainNavHost.kt
+++ b/app/src/main/java/com/subin/cleanbookstore/presentation/navigation/MainNavHost.kt
@@ -7,6 +7,8 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.toRoute
+import com.subin.cleanbookstore.presentation.bookmark.BookmarkScreen
+import com.subin.cleanbookstore.presentation.bookmark.BookmarkViewModel
 import com.subin.cleanbookstore.presentation.detail.DetailScreen
 import com.subin.cleanbookstore.presentation.search.BookSearchViewModel
 import com.subin.cleanbookstore.presentation.search.SearchScreen
@@ -38,9 +40,15 @@ fun MainNavHost(
             DetailScreen(bookId = detail.bookId, onBackClick = { navController.popBackStack() })
         }
 
-        // 3. 즐겨찾기 화면 (나중에 구현)
         composable<NavRoute.Bookmark> {
-            // BookmarkScreen()
+            val viewModel: BookmarkViewModel = hiltViewModel()
+
+            BookmarkScreen(
+                viewModel = viewModel,
+                onBookClick = { id ->
+                    navController.navigate(NavRoute.Detail(bookId = id))
+                }
+            )
         }
     }
 }

--- a/app/src/main/java/com/subin/cleanbookstore/presentation/navigation/NavRoute.kt
+++ b/app/src/main/java/com/subin/cleanbookstore/presentation/navigation/NavRoute.kt
@@ -1,17 +1,25 @@
 package com.subin.cleanbookstore.presentation.navigation
 
 import android.annotation.SuppressLint
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.Search
 import kotlinx.serialization.Serializable
 
 @Serializable
 sealed interface NavRoute {
     @Serializable
-    data object Search : NavRoute
+    data object Search : NavRoute {
+        val title = "검색"
+        val icon = Icons.Default.Search
+    }
 
-    @SuppressLint("UnsafeOptInUsageError")
+    @Serializable
+    data object Bookmark : NavRoute {
+        val title = "북마크"
+        val icon = Icons.Default.Favorite
+    }
+
     @Serializable
     data class Detail(val bookId: String) : NavRoute
-
-    @Serializable
-    data object Bookmark : NavRoute
 }

--- a/app/src/main/java/com/subin/cleanbookstore/presentation/search/BookSearchViewModel.kt
+++ b/app/src/main/java/com/subin/cleanbookstore/presentation/search/BookSearchViewModel.kt
@@ -95,6 +95,11 @@ class BookSearchViewModel @Inject constructor(
         }
     }
 
+    fun resetSearchState() {
+        _searchResults.value = emptyList()
+        _loadState.value = BookSearchUiState.Empty
+    }
+
     fun onBookmarkClick(book: Book) {
         viewModelScope.launch {
             toggleBookmarkUseCase(book)

--- a/app/src/main/java/com/subin/cleanbookstore/presentation/search/SearchScreen.kt
+++ b/app/src/main/java/com/subin/cleanbookstore/presentation/search/SearchScreen.kt
@@ -37,7 +37,16 @@ fun SearchScreen(
         uiState = uiState,
         recentHistory = recentHistory,
         searchQuery = searchQuery,
-        onQueryChange = { searchQuery = it },
+        onQueryChange = { query ->
+            searchQuery = query
+            if (query.isEmpty()) {
+                viewModel.resetSearchState()
+            }
+        },
+        onClearQuery = {
+            searchQuery = ""
+            viewModel.resetSearchState()
+        },
         onSearch = {
             if (searchQuery.isNotBlank()) {
                 viewModel.searchBooks(searchQuery)
@@ -63,6 +72,7 @@ private fun SearchContent(
     searchQuery: String,
     onQueryChange: (String) -> Unit,
     onSearch: () -> Unit,
+    onClearQuery: () -> Unit,
     onBookClick: (String) -> Unit,
     onLikeClick: (Book) -> Unit,
     onHistoryClick: (String) -> Unit,
@@ -79,8 +89,14 @@ private fun SearchContent(
             label = { Text("도서 검색") },
             placeholder = { Text("제목을 입력해 보세요") },
             trailingIcon = {
-                IconButton(onClick = onSearch) {
-                    Icon(imageVector = Icons.Default.Search, contentDescription = "검색 아이콘")
+                if (searchQuery.isNotEmpty()) {
+                    IconButton(onClick = onClearQuery) {
+                        Icon(imageVector = Icons.Default.Close, contentDescription = "지우기")
+                    }
+                } else {
+                    IconButton(onClick = onSearch) {
+                        Icon(imageVector = Icons.Default.Search, contentDescription = "검색 아이콘")
+                    }
                 }
             },
             singleLine = true,


### PR DESCRIPTION
Scaffold와 NavigationBar를 이용한 메인 UI 구조 설계

Type-safe Navigation(NavRoute) 기반의 화면 전환 로직 구현

로컬 DB 연동을 통한 실시간 북마크 리스트 화면(BookmarkScreen) 추가

검색어 초기화 및 검색 상태 리셋 로직 추가 (최근 검색어 노출 개선)

북마크 화면 내 리스트 삭제 및 상세 페이지 이동 연동 완료

Close #22 