### PR TITLE
feat: Paging 3를 이용한 도서 검색 무한 스크롤 구현 (#25)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -59,7 +59,6 @@ kotlin{
 }
 
 dependencies {
-    // 1. Android & Lifecycle
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
 
@@ -79,4 +78,7 @@ dependencies {
     implementation(libs.coil.compose)
 
     implementation(libs.kotlinx.serialization.json)
+
+    implementation(libs.androidx.paging.runtime)
+    implementation(libs.androidx.paging.compose)
 }

--- a/app/src/main/java/com/subin/cleanbookstore/data/remote/api/BooksApiService.kt
+++ b/app/src/main/java/com/subin/cleanbookstore/data/remote/api/BooksApiService.kt
@@ -13,6 +13,7 @@ interface BooksApiService {
     @GET("volumes")
     suspend fun searchBooks(
         @Query("q") query: String,
+        @Query("startIndex") startIndex: Int = 0,
         @Query("maxResults") maxResults: Int = 10,
         @Query("key") apiKey: String = BuildConfig.BOOKS_API_KEY
     ): BookSearchResponse

--- a/app/src/main/java/com/subin/cleanbookstore/data/remote/paging/BookPagingSource.kt
+++ b/app/src/main/java/com/subin/cleanbookstore/data/remote/paging/BookPagingSource.kt
@@ -1,0 +1,54 @@
+package com.subin.cleanbookstore.data.remote.paging
+
+import androidx.paging.PagingSource
+import androidx.paging.PagingState
+import com.subin.cleanbookstore.data.mapper.toDomain
+import com.subin.cleanbookstore.data.remote.api.BooksApiService
+import com.subin.cleanbookstore.domain.model.Book
+import retrofit2.HttpException
+import java.io.IOException
+
+class BookPagingSource(
+    private val apiService: BooksApiService,
+    private val query: String
+) : PagingSource<Int, Book>() {
+
+    override suspend fun load(params: LoadParams<Int>): LoadResult<Int, Book> {
+        val position = params.key ?: 0
+
+        return try {
+            val response = apiService.searchBooks(
+                query = query,
+                startIndex = position,
+                maxResults = params.loadSize
+            )
+
+            val books = response.items?.map { it.toDomain() } ?: emptyList()
+
+            val nextKey = if (books.isEmpty() || books.size < params.loadSize) {
+                null
+            } else {
+                position + params.loadSize
+            }
+
+            LoadResult.Page(
+                data = books,
+                prevKey = if (position == 0) null else position - params.loadSize,
+                nextKey = nextKey
+            )
+        } catch (exception: IOException) {
+            LoadResult.Error(exception)
+        } catch (exception: HttpException) {
+            LoadResult.Error(exception)
+        } catch (exception: Exception) {
+            LoadResult.Error(exception)
+        }
+    }
+
+    override fun getRefreshKey(state: PagingState<Int, Book>): Int? {
+        return state.anchorPosition?.let { anchorPosition ->
+            state.closestPageToPosition(anchorPosition)?.prevKey?.plus(state.config.pageSize)
+                ?: state.closestPageToPosition(anchorPosition)?.nextKey?.minus(state.config.pageSize)
+        }
+    }
+}

--- a/app/src/main/java/com/subin/cleanbookstore/data/repository/BookSearchRepositoryImpl.kt
+++ b/app/src/main/java/com/subin/cleanbookstore/data/repository/BookSearchRepositoryImpl.kt
@@ -1,28 +1,31 @@
 package com.subin.cleanbookstore.data.repository
 
+import androidx.paging.Pager
+import androidx.paging.PagingConfig
+import androidx.paging.PagingData
 import com.subin.cleanbookstore.core.DataResult
 import com.subin.cleanbookstore.data.mapper.toDomain
 import com.subin.cleanbookstore.data.remote.api.BooksApiService
+import com.subin.cleanbookstore.data.remote.paging.BookPagingSource
 import com.subin.cleanbookstore.domain.model.Book
 import com.subin.cleanbookstore.domain.repository.BookSearchRepository
+import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 
 class BookSearchRepositoryImpl @Inject constructor(
     private val apiService: BooksApiService
 ) : BookSearchRepository {
 
-    override suspend fun searchBooks(query: String): DataResult<List<Book>> {
-        return try {
-            val response = apiService.searchBooks(query)
-            val books = response.items?.map { it.toDomain() } ?: emptyList()
-            DataResult.Success(books)
-        } catch (e: java.net.UnknownHostException) {
-            DataResult.Error(Exception("네트워크 연결을 확인해 주세요."))
-        } catch (e: retrofit2.HttpException) {
-            DataResult.Error(Exception("서버 응답에 문제가 발생했습니다. (Error: ${e.code()})"))
-        } catch (e: Exception) {
-            DataResult.Error(e)
-        }
+    override fun searchBooks(query: String): Flow<PagingData<Book>> {
+        return Pager(
+            config = PagingConfig(
+                pageSize = 10,
+                enablePlaceholders = false
+            ),
+            pagingSourceFactory = {
+                BookPagingSource(apiService, query)
+            }
+        ).flow
     }
 
     override suspend fun getBookDetails(bookId: String): DataResult<Book> {

--- a/app/src/main/java/com/subin/cleanbookstore/domain/repository/BookSearchRepository.kt
+++ b/app/src/main/java/com/subin/cleanbookstore/domain/repository/BookSearchRepository.kt
@@ -1,9 +1,11 @@
 package com.subin.cleanbookstore.domain.repository
 
+import androidx.paging.PagingData
 import com.subin.cleanbookstore.core.DataResult
 import com.subin.cleanbookstore.domain.model.Book
+import kotlinx.coroutines.flow.Flow
 
 interface BookSearchRepository {
-    suspend fun searchBooks(query: String): DataResult<List<Book>>
+    fun searchBooks(query: String): Flow<PagingData<Book>>
     suspend fun getBookDetails(bookId: String): DataResult<Book>
 }

--- a/app/src/main/java/com/subin/cleanbookstore/domain/usecase/GetSearchBooksUseCase.kt
+++ b/app/src/main/java/com/subin/cleanbookstore/domain/usecase/GetSearchBooksUseCase.kt
@@ -1,14 +1,15 @@
 package com.subin.cleanbookstore.domain.usecase
 
-import com.subin.cleanbookstore.core.DataResult
+import androidx.paging.PagingData
 import com.subin.cleanbookstore.domain.model.Book
 import com.subin.cleanbookstore.domain.repository.BookSearchRepository
+import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 
 class GetSearchBooksUseCase @Inject constructor(
     private val repository: BookSearchRepository
 ) {
-    suspend operator fun invoke(query: String): DataResult<List<Book>> {
+    operator fun invoke(query: String): Flow<PagingData<Book>> {
         return repository.searchBooks(query)
     }
 }

--- a/app/src/main/java/com/subin/cleanbookstore/presentation/search/BookSearchViewModel.kt
+++ b/app/src/main/java/com/subin/cleanbookstore/presentation/search/BookSearchViewModel.kt
@@ -1,9 +1,10 @@
 package com.subin.cleanbookstore.presentation.search
 
-import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.subin.cleanbookstore.core.DataResult
+import androidx.paging.PagingData
+import androidx.paging.cachedIn
+import androidx.paging.map
 import com.subin.cleanbookstore.domain.model.Book
 import com.subin.cleanbookstore.domain.usecase.DeleteSearchHistoryUseCase
 import com.subin.cleanbookstore.domain.usecase.GetBookmarkListUseCase
@@ -12,6 +13,7 @@ import com.subin.cleanbookstore.domain.usecase.GetSearchBooksUseCase
 import com.subin.cleanbookstore.domain.usecase.SaveSearchKeywordUseCase
 import com.subin.cleanbookstore.domain.usecase.ToggleBookmarkUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -32,56 +34,36 @@ class BookSearchViewModel @Inject constructor(
             started = SharingStarted.WhileSubscribed(5000),
             initialValue = emptyList()
         )
-    private val _searchResults = MutableStateFlow<List<Book>>(emptyList())
 
-    private val _loadState = MutableStateFlow<BookSearchUiState>(BookSearchUiState.Empty)
+    private val _searchQuery = MutableStateFlow("")
+    val searchQuery = _searchQuery.asStateFlow()
 
-    val uiState: StateFlow<BookSearchUiState> = combine(
-        _searchResults,
-        getBookmarkListUseCase(),
-        _loadState
-    ) { results, bookmarks, loadState ->
-        val syncBooks = results.map { book ->
-            book.copy(isFavorite = bookmarks.any { it.id == book.id })
+    @OptIn(ExperimentalCoroutinesApi::class)
+    val searchPagingData: Flow<PagingData<Book>> = _searchQuery
+        .filter { it.isNotBlank() }
+        .flatMapLatest { query ->
+            getSearchBooksUseCase(query)
         }
-
-        when (loadState) {
-            is BookSearchUiState.Loading -> BookSearchUiState.Loading
-            is BookSearchUiState.Error -> BookSearchUiState.Error(loadState.message)
-            else -> {
-                if (syncBooks.isEmpty()) BookSearchUiState.Empty
-                else BookSearchUiState.Success(syncBooks)
+        .cachedIn(viewModelScope)
+        .combine(getBookmarkListUseCase()) { pagingData, bookmarks ->
+            pagingData.map { book ->
+                book.copy(isFavorite = bookmarks.any { it.id == book.id })
             }
         }
-    }.stateIn(
-        scope = viewModelScope,
-        started = SharingStarted.WhileSubscribed(5000),
-        initialValue = BookSearchUiState.Empty
-    )
-
-    private var searchJob: kotlinx.coroutines.Job? = null
 
     fun searchBooks(query: String) {
         if (query.isBlank()) return
 
-        searchJob?.cancel()
-        searchJob = viewModelScope.launch {
+        viewModelScope.launch {
             saveSearchKeywordUseCase(query)
-
-            _loadState.value = BookSearchUiState.Loading
-
-            when (val result = getSearchBooksUseCase(query)) {
-                is DataResult.Success -> {
-                    _searchResults.value = result.data
-                    _loadState.value = BookSearchUiState.Success(result.data)
-                }
-                is DataResult.Error -> {
-                    val errorMessage = result.exception.message ?: "검색 중 오류가 발생했습니다."
-                    _loadState.value = BookSearchUiState.Error(errorMessage)
-                }
-            }
         }
+        _searchQuery.value = query
     }
+
+    fun resetSearchState() {
+        _searchQuery.value = ""
+    }
+
 
     fun deleteHistory(keyword: String) {
         viewModelScope.launch {
@@ -93,11 +75,6 @@ class BookSearchViewModel @Inject constructor(
         viewModelScope.launch {
             deleteSearchHistoryUseCase.clearAll()
         }
-    }
-
-    fun resetSearchState() {
-        _searchResults.value = emptyList()
-        _loadState.value = BookSearchUiState.Empty
     }
 
     fun onBookmarkClick(book: Book) {

--- a/app/src/main/java/com/subin/cleanbookstore/presentation/search/SearchScreen.kt
+++ b/app/src/main/java/com/subin/cleanbookstore/presentation/search/SearchScreen.kt
@@ -19,6 +19,10 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.paging.LoadState
+import androidx.paging.compose.LazyPagingItems
+import androidx.paging.compose.collectAsLazyPagingItems
+import androidx.paging.compose.itemKey
 import com.subin.cleanbookstore.domain.model.Book
 import com.subin.cleanbookstore.presentation.components.BookItem
 
@@ -27,14 +31,14 @@ fun SearchScreen(
     viewModel: BookSearchViewModel,
     onBookClick: (String) -> Unit
 ) {
-    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val searchPagingItems = viewModel.searchPagingData.collectAsLazyPagingItems()
     val recentHistory by viewModel.recentSearchHistory.collectAsStateWithLifecycle()
 
     var searchQuery by rememberSaveable { mutableStateOf("") }
     val keyboardController = LocalSoftwareKeyboardController.current
 
     SearchContent(
-        uiState = uiState,
+        books = searchPagingItems,
         recentHistory = recentHistory,
         searchQuery = searchQuery,
         onQueryChange = { query ->
@@ -67,7 +71,7 @@ fun SearchScreen(
 
 @Composable
 private fun SearchContent(
-    uiState: BookSearchUiState,
+    books: LazyPagingItems<Book>,
     recentHistory: List<String>,
     searchQuery: String,
     onQueryChange: (String) -> Unit,
@@ -109,7 +113,7 @@ private fun SearchContent(
                 .fillMaxSize()
                 .weight(1f)
         ) {
-            if (uiState is BookSearchUiState.Empty) {
+            if (searchQuery.isEmpty()) {
                 RecentSearchList(
                     history = recentHistory,
                     onHistoryClick = onHistoryClick,
@@ -117,36 +121,53 @@ private fun SearchContent(
                     onClearAllHistory = onClearAllHistory
                 )
             } else {
-                when (uiState) {
-                    is BookSearchUiState.Loading -> {
-                        CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
+                LazyColumn(
+                    modifier = Modifier.fillMaxSize(),
+                    contentPadding = PaddingValues(bottom = 16.dp)
+                ) {
+                    items(
+                        count = books.itemCount
+                    ) { index ->
+                        val book = books[index]
+                        if (book != null) {
+                            BookItem(
+                                book = book,
+                                isLiked = book.isFavorite,
+                                onClick = { onBookClick(book.id) },
+                                onLikeClick = { onLikeClick(book) }
+                            )
+                        }
                     }
-                    is BookSearchUiState.Success -> {
-                        LazyColumn(
-                            modifier = Modifier.fillMaxSize(),
-                            contentPadding = PaddingValues(bottom = 16.dp)
-                        ) {
-                            items(
-                                items = uiState.books,
-                                key = { it.id }
-                            ) { book ->
-                                BookItem(
-                                    book = book,
-                                    isLiked = book.isFavorite,
-                                    onClick = { onBookClick(book.id) },
-                                    onLikeClick = { onLikeClick(book) }
-                                )
+
+                    books.apply {
+                        when {
+                            loadState.refresh is LoadState.Loading -> {
+                                item {
+                                    Box(modifier = Modifier.fillParentMaxSize(), contentAlignment = Alignment.Center) {
+                                        CircularProgressIndicator()
+                                    }
+                                }
+                            }
+                            loadState.append is LoadState.Loading -> {
+                                item {
+                                    Box(modifier = Modifier.fillMaxWidth().padding(16.dp), contentAlignment = Alignment.Center) {
+                                        CircularProgressIndicator(modifier = Modifier.size(24.dp))
+                                    }
+                                }
+                            }
+                            loadState.refresh is LoadState.Error -> {
+                                val error = books.loadState.refresh as LoadState.Error
+                                item {
+                                    Box(modifier = Modifier.fillParentMaxSize(), contentAlignment = Alignment.Center) {
+                                        Text(
+                                            text = error.error.localizedMessage ?: "에러가 발생했습니다.",
+                                            color = MaterialTheme.colorScheme.error
+                                        )
+                                    }
+                                }
                             }
                         }
                     }
-                    is BookSearchUiState.Error -> {
-                        Text(
-                            text = uiState.message,
-                            color = MaterialTheme.colorScheme.error,
-                            modifier = Modifier.align(Alignment.Center)
-                        )
-                    }
-                    else -> {}
                 }
             }
         }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,6 +19,8 @@ coil = "2.6.0"
 
 kotlinxSerializationJson = "1.7.3"
 
+paging = "3.3.2"
+
 [libraries]
 # Android & Lifecycle
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -55,8 +57,11 @@ androidx-hilt-navigation-compose = { group = "androidx.hilt", name = "hilt-navig
 kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "coroutines" }
 coil-compose = { group = "io.coil-kt", name = "coil-compose", version.ref = "coil" }
 
-
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
+
+# Paging
+androidx-paging-runtime = { group = "androidx.paging", name = "paging-runtime-ktx", version.ref = "paging" }
+androidx-paging-compose = { group = "androidx.paging", name = "paging-compose", version.ref = "paging" }
 
 [bundles]
 compose = [


### PR DESCRIPTION
- Paging 3 라이브러리 의존성 추가
- Google Books API의 `startIndex`를 활용한 `BookPagingSource` 구현 (데이터 로드 및 페이징 종료 로직 포함)
- `BookSearchRepository` 및 `UseCase`의 반환 타입을 `Flow<PagingData<Book>>`로 변경하여 데이터 파이프라인 구축
- `BookSearchViewModel`에서 `flatMapLatest`와 `cachedIn`을 활용해 검색 스트림 최적화 및 북마크 상태 실시간 동기화(`combine`) 적용
- `SearchScreen`의 `LazyColumn`에 `collectAsLazyPagingItems` 적용
- `LoadState`를 활용하여 상태별 UI(최초 로딩, 하단 추가 로딩, 에러 화면) 구현
- 구글 API의 중복 데이터 응답으로 인한 `LazyColumn` Key 충돌(Crash) 이슈 해결

Resolves #25